### PR TITLE
Correct broken google analytics tag

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,6 +3,15 @@
   <head>
     <title>Bushido Lab</title>
     <%= csrf_meta_tags %>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-112136387-1"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'UA-112136387-1');
+    </script>
 
     <meta name="viewport" content="initial-scale=1, maximum-scale=1">
 


### PR DESCRIPTION
This PR will correct the broken google analytics tag.

Site has not been tracking visitor analytic information for the past 3 months...

Test and worked on local setup.